### PR TITLE
Add random key trainer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# RandomKeyStrokeTrainner
-Web App to show a big Character taken from the keyboard layout and wait for the user to press it on the keyboard.
+# Random Key Stroke Trainer
+
+Aplicación web simple que muestra un carácter aleatorio del layout del teclado actual y espera a que el usuario lo presione. Cuando se acierta, se muestra un nuevo carácter.
+
+## Características
+- Detecta el layout de teclado disponible en el navegador.
+- Muestra un botón centrado ocupando ~70% de la ventana con el carácter actual.
+- Soporta modo claro y oscuro con un interruptor.
+
+## Uso
+1. Abre `index.html` en tu navegador.
+2. Presiona la tecla que coincide con el carácter mostrado.
+3. Cambia entre tema claro y oscuro con el interruptor en la esquina superior derecha.
+
+## Nota
+La detección de layout depende de la API experimental `navigator.keyboard`. Si no está disponible, se usa un conjunto básico de letras.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,37 @@
+async function loadLayout() {
+  if (navigator.keyboard && navigator.keyboard.getLayoutMap) {
+    try {
+      const layoutMap = await navigator.keyboard.getLayoutMap();
+      const chars = Array.from(layoutMap.values()).filter((k) => k.length === 1);
+      return Array.from(new Set(chars));
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  return 'abcdefghijklmnopqrstuvwxyz'.split('');
+}
+
+let characters = [];
+let current = '';
+
+function nextChar() {
+  if (characters.length === 0) return;
+  const idx = Math.floor(Math.random() * characters.length);
+  current = characters[idx];
+  document.getElementById('charDisplay').textContent = current;
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key.toLowerCase() === current.toLowerCase()) {
+    nextChar();
+  }
+});
+
+document.getElementById('themeToggle').addEventListener('change', (e) => {
+  document.body.setAttribute('data-theme', e.target.checked ? 'dark' : 'light');
+});
+
+loadLayout().then((chars) => {
+  characters = chars;
+  nextChar();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Random Key Stroke Trainer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="theme-switch">
+    <label>
+      <input type="checkbox" id="themeToggle" /> Tema oscuro
+    </label>
+  </div>
+  <button id="charDisplay"></button>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,40 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #f0f0f0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  font-family: sans-serif;
+}
+
+.theme-switch {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+#charDisplay {
+  width: 70vmin;
+  height: 70vmin;
+  font-size: 50vmin;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- add static web app that displays random character based on keyboard layout
- support light/dark theme and large central button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943a30daec8325b3edb000fd0eac20