### PR TITLE
Add random key trainer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# RandomKeyStrokeTrainner
-Web App to show a big Character taken from the keyboard layout and wait for the user to press it on the keyboard.
+# Random Key Stroke Trainer
+
+Aplicación web simple que muestra un carácter aleatorio del layout del teclado actual y espera a que el usuario lo presione. Cuando se acierta, se muestra un nuevo carácter.
+
+## Características
+- Detecta el layout de teclado disponible en el navegador.
+- Muestra un botón centrado ocupando ~70% de la ventana con el carácter actual.
+- Soporta modo claro y oscuro con un interruptor.
+- Botón de configuración para elegir qué tipos de caracteres practicar (mayúsculas, minúsculas, números y especiales).
+- Monitor de velocidad en pulsaciones por minuto y contador de aciertos con indicador de "bien", "mal" o "nada".
+
+## Uso
+1. Abre `index.html` en tu navegador.
+2. Presiona la tecla que coincide con el carácter mostrado.
+3. Cambia entre tema claro y oscuro con el interruptor en la esquina superior derecha.
+4. Usa el botón de configuración para incluir o excluir tipos de caracteres.
+5. Observa tu contador de aciertos y la velocidad de tecleo en la parte inferior.
+
+## Nota
+La detección de layout depende de la API experimental `navigator.keyboard`. Si no está disponible, se usa un conjunto básico de letras.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,110 @@
+async function loadLayout() {
+  if (navigator.keyboard && navigator.keyboard.getLayoutMap) {
+    try {
+      const layoutMap = await navigator.keyboard.getLayoutMap();
+      const chars = Array.from(layoutMap.values()).filter((k) => k.length === 1);
+      return Array.from(new Set(chars));
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  return 'abcdefghijklmnopqrstuvwxyz'.split('');
+}
+
+let characters = [];
+let current = '';
+
+let hits = 0;
+let totalPresses = 0;
+let startTime = null;
+let lastResult = 'nada';
+
+const config = {
+  lower: true,
+  upper: true,
+  numbers: true,
+  special: true,
+};
+
+let lowercaseChars = [];
+let digits = [];
+let specialChars = [];
+
+function rebuildCharacters() {
+  let chars = [];
+  if (config.lower) chars = chars.concat(lowercaseChars);
+  if (config.upper) chars = chars.concat(lowercaseChars.map((c) => c.toUpperCase()));
+  if (config.numbers) chars = chars.concat(digits);
+  if (config.special) chars = chars.concat(specialChars);
+  characters = Array.from(new Set(chars));
+  nextChar();
+  lastResult = 'nada';
+  updateStats();
+}
+
+function nextChar() {
+  if (characters.length === 0) return;
+  const idx = Math.floor(Math.random() * characters.length);
+  current = characters[idx];
+  document.getElementById('charDisplay').textContent = current;
+}
+
+function updateStats() {
+  document.getElementById('hitCount').textContent = hits;
+  document.getElementById('hitResult').textContent = lastResult;
+  if (!startTime) {
+    document.getElementById('speed').textContent = '0';
+    return;
+  }
+  const minutes = (Date.now() - startTime) / 60000;
+  const kpm = minutes > 0 ? (totalPresses / minutes).toFixed(2) : '0';
+  document.getElementById('speed').textContent = kpm;
+}
+
+document.addEventListener('keydown', (e) => {
+  if (!startTime) startTime = Date.now();
+  totalPresses++;
+  if (e.key === current) {
+    hits++;
+    lastResult = 'bien';
+    nextChar();
+  } else {
+    lastResult = 'mal';
+  }
+  updateStats();
+});
+
+document.getElementById('themeToggle').addEventListener('change', (e) => {
+  document.body.setAttribute('data-theme', e.target.checked ? 'dark' : 'light');
+});
+
+document.getElementById('configToggle').addEventListener('click', () => {
+  document.getElementById('configPanel').classList.toggle('hidden');
+});
+
+document.getElementById('lowercaseOpt').addEventListener('change', (e) => {
+  config.lower = e.target.checked;
+  rebuildCharacters();
+});
+
+document.getElementById('uppercaseOpt').addEventListener('change', (e) => {
+  config.upper = e.target.checked;
+  rebuildCharacters();
+});
+
+document.getElementById('numbersOpt').addEventListener('change', (e) => {
+  config.numbers = e.target.checked;
+  rebuildCharacters();
+});
+
+document.getElementById('specialOpt').addEventListener('change', (e) => {
+  config.special = e.target.checked;
+  rebuildCharacters();
+});
+
+loadLayout().then((chars) => {
+  lowercaseChars = chars.filter((c) => /[a-z]/.test(c));
+  digits = chars.filter((c) => /[0-9]/.test(c));
+  specialChars = chars.filter((c) => !/[a-z0-9]/i.test(c));
+  rebuildCharacters();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Random Key Stroke Trainer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="theme-switch">
+    <label>
+      <input type="checkbox" id="themeToggle" /> Tema oscuro
+    </label>
+  </div>
+  <div class="config">
+    <button id="configToggle">Configuración</button>
+    <div id="configPanel" class="hidden">
+      <label><input type="checkbox" id="lowercaseOpt" checked /> Minúsculas</label>
+      <label><input type="checkbox" id="uppercaseOpt" checked /> Mayúsculas</label>
+      <label><input type="checkbox" id="numbersOpt" checked /> Números</label>
+      <label><input type="checkbox" id="specialOpt" checked /> Especiales</label>
+    </div>
+  </div>
+  <button id="charDisplay"></button>
+  <div id="stats">
+    <div>Contador: <span id="hitCount">0</span> - <span id="hitResult">nada</span></div>
+    <div>Velocidad: <span id="speed">0</span> ks/min</div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,68 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: #f0f0f0;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  font-family: sans-serif;
+}
+
+.theme-switch {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.config {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+#configPanel {
+  margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--text-color);
+  padding: 8px;
+}
+
+.hidden {
+  display: none;
+}
+
+#charDisplay {
+  width: 70vmin;
+  height: 70vmin;
+  font-size: 50vmin;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: default;
+}
+
+#stats {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add static web app that displays random character based on keyboard layout
- support light/dark theme and allow configuring which character types to use
- track keystroke speed and hit accuracy with a counter and ks/min monitor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943a30daec8325b3edb000fd0eac20